### PR TITLE
Fix 2.6 testing

### DIFF
--- a/trait_documenter/tests/test_file2.py
+++ b/trait_documenter/tests/test_file2.py
@@ -1,6 +1,6 @@
 from traits.api import Event, Float, Int, List
 
-from . import test_file
+from trait_documenter.tests import test_file
 
 test_file.Event = Event
 

--- a/trait_documenter/tests/test_get_trait_definition.py
+++ b/trait_documenter/tests/test_get_trait_definition.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
-import unittest
 
 from trait_documenter.tests import test_file, test_file2
-from trait_documenter.tests.testing import expected_failure_when, is_python_26
+from trait_documenter.tests.testing import (
+    expected_failure_when, is_python_26, unittest)
 from trait_documenter.tests.test_file import Dummy, dummy_function
 from trait_documenter.util import get_trait_definition, DefinitionError
 

--- a/trait_documenter/tests/test_module_trait_documenter.py
+++ b/trait_documenter/tests/test_module_trait_documenter.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
-import unittest
 
 import mock
 from sphinx.ext.autodoc import ModuleDocumenter, SUPPRESS
 
 from trait_documenter.module_trait_documenter import ModuleTraitDocumenter
 from trait_documenter.tests import test_file
-from trait_documenter.tests.testing import expected_failure_when, is_python_26
+from trait_documenter.tests.testing import (
+    expected_failure_when, is_python_26, unittest)
 from trait_documenter.tests.test_file import Dummy
 
 

--- a/trait_documenter/tests/testing.py
+++ b/trait_documenter/tests/testing.py
@@ -1,7 +1,11 @@
 def is_python_26():
     import sys
-    return sys.version_info < (2, 6)
+    return sys.version_info[:2] == (2, 6)
 
+if is_python_26():
+    import unittest2 as unittest
+else:
+    import unittest
 
 class expected_failure_when(object):
 
@@ -10,10 +14,6 @@ class expected_failure_when(object):
 
     def __call__(self, function):
         if self.condition:
-            if is_python_26():
-                import unittest2 as unittest
-            else:
-                import unittest
             return unittest.expectedFailure(function)
         else:
             return function


### PR DESCRIPTION
This PR fixes the issues with python 2.6 testing. Pending approval of https://github.com/sjagoe/haas/pull/144 all tests should now run on python 2.6